### PR TITLE
Add Tiobe TiCS to the CI

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,12 @@
+name: Tiobe TiCS Analysis
+
+on:
+    workflow_dispatch:
+    schedule:
+    - cron: "0 0 * * 1"  # Runs at midnight UTC every Monday
+
+jobs:
+    tics:
+        name: TiCs
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        secrets: inherit


### PR DESCRIPTION
Add a GH workflow to run a cronjob (every week on Monday) to run Tiobe TiCS scan on this repo.