### PR TITLE
ci: test remote build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@feature/v1
+    uses: canonical/observability/.github/workflows/charm-release.yaml@ci/use-charmcraft-remote-build-in-release
     secrets: inherit
     with:
       default-track: dev

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -39,11 +39,15 @@ config:
       default: "info"
       type: string
 
-base: ubuntu@24.04
-
 platforms:
-  amd64:
-  arm64:
+  ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
+  ubuntu@22.04:ppc64el:
+  ubuntu@22.04:s390x:
+  ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
+  ubuntu@24.04:ppc64el:
+  ubuntu@24.04:s390x:
 
 parts:
   charm:


### PR DESCRIPTION
Testing that remote build works. This workflow relies on the charm-release workflow in the observability repo.