### PR TITLE
test: COS integration - distributed topology

### DIFF
--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -1,0 +1,119 @@
+name: COS Integration Test
+# Validates that:
+#   1. The reusable deploy-cos workflow from observability-stack can successfully deploy COS
+#      in monolithic topology with seaweedfs as the storage backend.
+#   2. The o11y-tester charm can be deployed into the same Juju model as a running COS
+#      deployment and reaches active status.
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  # ── Job 1 ─────────────────────────────────────────────────────────────────
+  # Calls the reusable deploy-cos workflow directly to verify it works end-to-end.
+  deploy-cos:
+    name: Validate deploy-cos reusable workflow
+    uses: canonical/observability-stack/.github/workflows/deploy-cos.yml@feat/reusable-deploy-cos
+    with:
+      scale: monolithic
+      storage: seaweedfs
+
+  # ── Job 2 ─────────────────────────────────────────────────────────────────
+  # Full integration test: deploys COS (using the same Terraform module as the
+  # reusable workflow) and the tester charm into the same Juju model, then asserts
+  # both reach active status.
+  tester-alongside-cos:
+    name: Deploy o11y-tester alongside COS
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout o11y-tester-operator
+        uses: actions/checkout@v4
+
+      # ── Infrastructure setup (github-hosted) ──────────────────────────────
+      - name: Set up environment (github-hosted)
+        if: ${{ runner.environment == 'github-hosted' }}
+        run: |
+          sudo snap install concierge --classic
+          sudo concierge prepare \
+            --juju-channel 3.6/stable \
+            -p microk8s \
+            --extra-snaps terraform,astral-uv,charmcraft
+
+      # ── Infrastructure setup (self-hosted / IS runner) ────────────────────
+      - name: Install snaps (self-hosted)
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          sudo snap install juju --classic --channel=3.6/stable
+          sudo snap install terraform --classic
+          sudo snap install astral-uv --classic
+          sudo snap install charmcraft --classic
+
+      - name: Set up microk8s (self-hosted)
+        timeout-minutes: 15
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install retry -y
+          sudo snap install microk8s --channel "1.34-strict/stable" --classic
+          sudo adduser "$USER" snap_microk8s
+
+          until sudo iptables --list | grep -q -i "microk8s"
+          do
+            echo "MicroK8s has not yet configured iptables."
+            sleep 10
+          done
+
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable dns
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/coredns
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable hostpath-storage
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner
+
+          IPADDR=$(ip -4 -j route get 2.2.2.2 | sed -n -e 's/^.*prefsrc\":"\([^ "]*\).*/\1/p')
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable "metallb:$IPADDR-$IPADDR"
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable rbac
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+
+          mkdir ~/.kube/
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s config | sudo tee ~/.kube/config > /dev/null
+
+      - name: Bootstrap Juju (self-hosted)
+        timeout-minutes: 15
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: |
+          mkdir -p ~/.local/share/juju
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- juju bootstrap microk8s --config model-logs-size=10G microk8s
+          juju model-defaults logging-config='<root>=INFO; unit=DEBUG'
+
+      # ── Checkout the observability-stack branch under test ─────────────────
+      - name: Checkout observability-stack (feat/reusable-deploy-cos)
+        uses: actions/checkout@v4
+        with:
+          repository: canonical/observability-stack
+          ref: feat/reusable-deploy-cos
+          path: observability-stack
+
+      # ── Build the tester charm ─────────────────────────────────────────────
+      - name: Set up LXD
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: canonical/setup-lxd@main
+
+      - name: Build tester charm
+        run: charmcraft pack --verbosity brief
+
+      # ── Run the integration test ───────────────────────────────────────────
+      # The cos-integration tox environment runs only test_deploy_with_cos.py.
+      # The cos_deployed fixture inside that test deploys COS via Terraform into
+      # the pytest-operator model, waits for all COS apps to become active, then
+      # yields so the test can deploy the tester charm alongside COS.
+      - name: Run COS integration test
+        env:
+          OBS_STACK_PATH: observability-stack
+        run: |
+          CHARM_FILE=$(find . -maxdepth 1 -name "o11y-tester_*.charm" | head -1)
+          CHARM_PATH="${CHARM_FILE}" uv run tox -e cos-integration

--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -1,119 +1,72 @@
 name: COS Integration Test
 # Validates that:
-#   1. The reusable deploy-cos workflow from observability-stack can successfully deploy COS
+#   1. The deploy-cos composite action from observability-stack can successfully deploy COS
 #      in monolithic topology with seaweedfs as the storage backend.
-#   2. The o11y-tester charm can be deployed into the same Juju model as a running COS
-#      deployment and reaches active status.
+#   2. The o11y-tester charm can be deployed into the same Juju model and reaches active status.
+#
+# Everything runs as steps in a single job so all steps share the same runner, the same Juju
+# controller, and the same kubeconfig that the composite action sets up.
 
 on:
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner label (use a self-hosted label for a fully isolated environment)"
+        required: false
+        default: ubuntu-latest
 
 jobs:
-
-  # ── Job 1 ─────────────────────────────────────────────────────────────────
-  # Calls the reusable deploy-cos workflow directly to verify it works end-to-end.
-  deploy-cos:
-    name: Validate deploy-cos reusable workflow
-    uses: canonical/observability-stack/.github/workflows/deploy-cos.yml@feat/reusable-deploy-cos
-    with:
-      scale: monolithic
-      storage: seaweedfs
-
-  # ── Job 2 ─────────────────────────────────────────────────────────────────
-  # Full integration test: deploys COS (using the same Terraform module as the
-  # reusable workflow) and the tester charm into the same Juju model, then asserts
-  # both reach active status.
-  tester-alongside-cos:
-    name: Deploy o11y-tester alongside COS
-    runs-on: ubuntu-latest
+  cos-integration:
+    name: Deploy COS and test o11y-tester
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 90
 
     steps:
       - name: Checkout o11y-tester-operator
         uses: actions/checkout@v4
 
-      # ── Infrastructure setup (github-hosted) ──────────────────────────────
-      - name: Set up environment (github-hosted)
-        if: ${{ runner.environment == 'github-hosted' }}
-        run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare \
-            --juju-channel 3.6/stable \
-            -p microk8s \
-            --extra-snaps terraform,astral-uv,charmcraft
-
-      # ── Infrastructure setup (self-hosted / IS runner) ────────────────────
-      - name: Install snaps (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          sudo snap install juju --classic --channel=3.6/stable
-          sudo snap install terraform --classic
-          sudo snap install astral-uv --classic
-          sudo snap install charmcraft --classic
-
-      - name: Set up microk8s (self-hosted)
-        timeout-minutes: 15
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install retry -y
-          sudo snap install microk8s --channel "1.34-strict/stable" --classic
-          sudo adduser "$USER" snap_microk8s
-
-          until sudo iptables --list | grep -q -i "microk8s"
-          do
-            echo "MicroK8s has not yet configured iptables."
-            sleep 10
-          done
-
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable dns
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/coredns
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable hostpath-storage
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner
-
-          IPADDR=$(ip -4 -j route get 2.2.2.2 | sed -n -e 's/^.*prefsrc\":"\([^ "]*\).*/\1/p')
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable "metallb:$IPADDR-$IPADDR"
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable rbac
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
-
-          mkdir ~/.kube/
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s config | sudo tee ~/.kube/config > /dev/null
-
-      - name: Bootstrap Juju (self-hosted)
-        timeout-minutes: 15
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          mkdir -p ~/.local/share/juju
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- juju bootstrap microk8s --config model-logs-size=10G microk8s
-          juju model-defaults logging-config='<root>=INFO; unit=DEBUG'
-
-      # ── Checkout the observability-stack branch under test ─────────────────
-      - name: Checkout observability-stack (feat/reusable-deploy-cos)
-        uses: actions/checkout@v4
+      # ── Deploy COS ────────────────────────────────────────────────────────
+      # The composite action handles all infrastructure setup (microk8s, Juju, Terraform)
+      # for both github-hosted and self-hosted runners, then deploys COS via Terraform
+      # and waits for all applications to reach active status.
+      - name: Deploy COS
+        id: deploy-cos
+        uses: canonical/observability-stack/.github/actions/deploy-cos@feat/deploy-cos-composite-action
         with:
-          repository: canonical/observability-stack
-          ref: feat/reusable-deploy-cos
-          path: observability-stack
+          scale: monolithic
+          storage: seaweedfs
 
       # ── Build the tester charm ─────────────────────────────────────────────
+      # On github-hosted runners, LXD and the charm tooling are not pre-installed.
+      # On self-hosted runners these are expected to be present already.
       - name: Set up LXD
         if: ${{ runner.environment == 'github-hosted' }}
         uses: canonical/setup-lxd@main
 
+      - name: Install charm tooling
+        if: ${{ runner.environment == 'github-hosted' }}
+        run: |
+          sudo snap install astral-uv --classic
+          sudo snap install charmcraft --classic
+
       - name: Build tester charm
         run: charmcraft pack --verbosity brief
 
-      # ── Run the integration test ───────────────────────────────────────────
-      # The cos-integration tox environment runs only test_deploy_with_cos.py.
-      # The cos_deployed fixture inside that test deploys COS via Terraform into
-      # the pytest-operator model, waits for all COS apps to become active, then
-      # yields so the test can deploy the tester charm alongside COS.
-      - name: Run COS integration test
-        env:
-          OBS_STACK_PATH: observability-stack
+      # ── Deploy o11y-tester alongside COS ──────────────────────────────────
+      # At this point COS is already running in the model provided by the action.
+      # We deploy the tester charm into that same model and assert it becomes active,
+      # confirming the two deployments can coexist.
+      - name: Deploy o11y-tester
         run: |
           CHARM_FILE=$(find . -maxdepth 1 -name "o11y-tester_*.charm" | head -1)
-          CHARM_PATH="${CHARM_FILE}" uv run tox -e cos-integration
+          AGENT_IMAGE=$(python3 -c "import yaml; d=yaml.safe_load(open('charmcraft.yaml')); print(d['resources']['agent-image']['upstream-source'])")
+          juju deploy "${CHARM_FILE}" o11y-tester \
+            --model "${{ steps.deploy-cos.outputs.cos-model }}" \
+            --resource "agent-image=${AGENT_IMAGE}"
+
+      - name: Wait for o11y-tester to become active
+        run: |
+          juju wait-for application o11y-tester \
+            --model "${{ steps.deploy-cos.outputs.cos-model }}" \
+            --timeout 15m \
+            --query 'status == "active"'

--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -8,6 +8,10 @@ name: COS Integration Test
 # controller, and the same kubeconfig that the composite action sets up.
 
 on:
+  pull_request:
+    branches:
+      - main
+      - track/0
   workflow_dispatch:
     inputs:
       runner:

--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -17,12 +17,12 @@ on:
       runner:
         description: "Runner label (use a self-hosted label for a fully isolated environment)"
         required: false
-        default: ubuntu-latest
+        default: self-hosted-linux-amd64-noble-large
 
 jobs:
   cos-integration:
     name: Deploy COS and test o11y-tester
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'self-hosted-linux-amd64-noble-large' }}
     timeout-minutes: 90
 
     steps:
@@ -35,7 +35,7 @@ jobs:
       # and waits for all applications to reach active status.
       - name: Deploy COS
         id: deploy-cos
-        uses: canonical/observability-stack/.github/actions/deploy-cos@feat/deploy-cos-composite-action
+        uses: canonical/observability-stack/.github/actions/deploy-cos@feat/reusable-deploy-cos
         with:
           scale: monolithic
           storage: seaweedfs

--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -1,11 +1,7 @@
-name: COS Integration Test
-# Validates that:
-#   1. The deploy-cos composite action from observability-stack can successfully deploy COS
-#      in monolithic topology with seaweedfs as the storage backend.
-#   2. The o11y-tester charm can be deployed into the same Juju model and reaches active status.
-#
-# Everything runs as steps in a single job so all steps share the same runner, the same Juju
-# controller, and the same kubeconfig that the composite action sets up.
+name: COS Integration Test - Distributed
+# Validates that the deploy-cos composite action can deploy COS in distributed topology
+# with seaweedfs as the storage backend, and that o11y-tester reaches active status
+# in that model.
 
 on:
   pull_request:
@@ -17,32 +13,25 @@ on:
       runner:
         description: "Runner label (use a self-hosted label for a fully isolated environment)"
         required: false
-        default: self-hosted-linux-amd64-noble-large
+        default: self-hosted-linux-amd64-noble-xlarge
 
 jobs:
   cos-integration:
-    name: Deploy COS and test o11y-tester
-    runs-on: ${{ inputs.runner || 'self-hosted-linux-amd64-noble-large' }}
-    timeout-minutes: 90
+    name: Deploy COS and test o11y-tester (distributed + seaweedfs)
+    runs-on: ${{ inputs.runner || 'self-hosted-linux-amd64-noble-xlarge' }}
+    timeout-minutes: 120
 
     steps:
       - name: Checkout o11y-tester-operator
         uses: actions/checkout@v4
 
-      # ── Deploy COS ────────────────────────────────────────────────────────
-      # The composite action handles all infrastructure setup (microk8s, Juju, Terraform)
-      # for both github-hosted and self-hosted runners, then deploys COS via Terraform
-      # and waits for all applications to reach active status.
       - name: Deploy COS
         id: deploy-cos
         uses: canonical/observability-stack/.github/actions/deploy-cos@feat/reusable-deploy-cos
         with:
-          scale: monolithic
+          scale: distributed
           storage: seaweedfs
 
-      # ── Build the tester charm ─────────────────────────────────────────────
-      # On github-hosted runners, LXD and the charm tooling are not pre-installed.
-      # On self-hosted runners these are expected to be present already.
       - name: Set up LXD
         if: ${{ runner.environment == 'github-hosted' }}
         uses: canonical/setup-lxd@main
@@ -56,10 +45,6 @@ jobs:
       - name: Build tester charm
         run: charmcraft pack --verbosity brief
 
-      # ── Deploy o11y-tester alongside COS ──────────────────────────────────
-      # At this point COS is already running in the model provided by the action.
-      # We deploy the tester charm into that same model and assert it becomes active,
-      # confirming the two deployments can coexist.
       - name: Deploy o11y-tester
         run: |
           CHARM_FILE=$(find . -maxdepth 1 -name "o11y-tester_*.charm" | head -1)

--- a/.github/workflows/cos-integration.yaml
+++ b/.github/workflows/cos-integration.yaml
@@ -32,12 +32,7 @@ jobs:
           scale: distributed
           storage: seaweedfs
 
-      - name: Set up LXD
-        if: ${{ runner.environment == 'github-hosted' }}
-        uses: canonical/setup-lxd@main
-
       - name: Install charm tooling
-        if: ${{ runner.environment == 'github-hosted' }}
         run: |
           sudo snap install astral-uv --classic
           sudo snap install charmcraft --classic

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/0
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,13 @@ on:
       - main
       - track/3.0
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@feat/tf-tagging

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,9 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import functools
+import json
 import logging
 import os
 from collections import defaultdict
@@ -47,3 +49,53 @@ async def charm(ops_test: OpsTest) -> str:
     charm = await ops_test.build_charm(".")
     assert charm
     return str(charm)
+
+
+@pytest.fixture(scope="module")
+async def cos_deployed(ops_test: OpsTest):
+    """Deploy COS to the test model via the observability-stack Terraform module.
+
+    Reads OBS_STACK_PATH from the environment (defaults to "observability-stack") to find the
+    checked-out observability-stack repository. Deploys COS in monolithic topology with seaweedfs
+    as the storage backend, then waits until all COS applications reach active status.
+    """
+    assert ops_test.model is not None
+
+    obs_stack_path = os.environ.get("OBS_STACK_PATH", "observability-stack")
+    tf_dir = os.path.join(obs_stack_path, "terraform", "cos-dev")
+    model_name = ops_test.model_name
+
+    # Resolve the model UUID via the juju CLI (same approach as the deploy-cos workflow)
+    proc = await asyncio.create_subprocess_exec(
+        "juju", "show-model", model_name, "--format", "json",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    assert proc.returncode == 0, f"juju show-model failed: {stderr.decode()}"
+    model_uuid = json.loads(stdout)[model_name]["model-uuid"]
+
+    logger.info("Deploying COS to model %s (uuid=%s) via Terraform", model_name, model_uuid)
+
+    proc = await asyncio.create_subprocess_exec("terraform", "init", cwd=tf_dir)
+    assert (await proc.wait()) == 0, "terraform init failed"
+
+    proc = await asyncio.create_subprocess_exec(
+        "terraform", "apply", "-auto-approve",
+        f"-var=model_uuid={model_uuid}",
+        "-var=topology=monolithic",
+        "-var=storage_backend=seaweedfs",
+        cwd=tf_dir,
+    )
+    assert (await proc.wait()) == 0, "terraform apply failed"
+
+    logger.info("Waiting for all COS applications to reach active status (timeout: 30m)")
+    proc = await asyncio.create_subprocess_exec(
+        "juju", "wait-for", "model", model_name,
+        "--timeout", "30m",
+        "--query", "forEach(applications, app => app.status == \"active\")",
+    )
+    assert (await proc.wait()) == 0, "COS failed to reach active state within 30 minutes"
+
+    logger.info("COS is active in model %s", model_name)
+    yield model_name

--- a/tests/integration/test_deploy_with_cos.py
+++ b/tests/integration/test_deploy_with_cos.py
@@ -1,9 +1,16 @@
 """Integration test: deploy o11y-tester alongside a running COS deployment."""
 
+import os
 from typing import Dict
 
+import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+
+pytestmark = pytest.mark.skipif(
+    "OBS_STACK_PATH" not in os.environ,
+    reason="OBS_STACK_PATH not set; skipping COS integration test (run via tox -e cos-integration)",
+)
 
 
 def _charm_resources(metadata_file: str = "charmcraft.yaml") -> Dict[str, str]:

--- a/tests/integration/test_deploy_with_cos.py
+++ b/tests/integration/test_deploy_with_cos.py
@@ -1,0 +1,24 @@
+"""Integration test: deploy o11y-tester alongside a running COS deployment."""
+
+from typing import Dict
+
+import yaml
+from pytest_operator.plugin import OpsTest
+
+
+def _charm_resources(metadata_file: str = "charmcraft.yaml") -> Dict[str, str]:
+    with open(metadata_file, "r") as file:
+        metadata = yaml.safe_load(file)
+    return {res: data["upstream-source"] for res, data in metadata["resources"].items()}
+
+
+async def test_deploy_alongside_cos(ops_test: OpsTest, charm: str, cos_deployed: str):
+    """Deploy the tester charm in the same model as a running COS and verify it becomes active.
+
+    The cos_deployed fixture (from conftest.py) deploys the full COS stack to the test model
+    before this test runs. This test then deploys the tester charm into that same model and
+    asserts it reaches active status, confirming the two deployments can coexist.
+    """
+    assert ops_test.model is not None
+    await ops_test.model.deploy(charm, "o11y-tester", resources=_charm_resources())
+    await ops_test.model.wait_for_idle(apps=["o11y-tester"], status="active", timeout=300)

--- a/tests/integration/test_deploy_with_cos.py
+++ b/tests/integration/test_deploy_with_cos.py
@@ -9,7 +9,7 @@ from pytest_operator.plugin import OpsTest
 
 pytestmark = pytest.mark.skipif(
     "OBS_STACK_PATH" not in os.environ,
-    reason="OBS_STACK_PATH not set; skipping COS integration test (run via tox -e cos-integration)",
+    reason="OBS_STACK_PATH not set; skip (run via tox -e cos-integration)",
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
-passenv = CHARM_PATH
+passenv = CHARM_PATH,OBS_STACK_PATH
 
 [testenv:lock]
 description = Update uv.lock with the latest deps
@@ -57,6 +57,11 @@ commands =
 description = Run integration tests
 commands =
     uv run {[vars]uv_flags} pytest --exitfirst {[vars]tst_path}/integration {posargs}
+
+[testenv:cos-integration]
+description = Run the COS integration test (deploys COS alongside the tester charm)
+commands =
+    uv run {[vars]uv_flags} pytest --exitfirst {[vars]tst_path}/integration/test_deploy_with_cos.py {posargs}
 
 [testenv:qualitygate-beta]
 allowlist_externals = bash


### PR DESCRIPTION
Tests the `deploy-cos` composite action ([observability-stack#299](https://github.com/canonical/observability-stack/pull/299)) with distributed topology and seaweedfs storage.

Runs on `self-hosted-linux-amd64-noble-xlarge` (more units require more resources).